### PR TITLE
Use the form without a data class

### DIFF
--- a/src/Controller/ComicsController.php
+++ b/src/Controller/ComicsController.php
@@ -56,22 +56,26 @@ class ComicsController extends AbstractController
             null,
             'Uploading a chapter is only available for authors'
         );
-        $chapter = new Chapter();
-        $form = $this->createForm(UploadType::class, $chapter);
+        $form = $this->createForm(UploadType::class);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+
             /** @var UploadedFile[] $files */
-            $files = $chapter->getFolder();
+            $files = $data['files'];
             $folderName = $this->generateUniqueFileName();
             $chapterFolderAbsolutePath = $this->getChapterFolderAbsolutePath($folderName);
             foreach ($files as $file) {
                 $this->unzip($file, $chapterFolderAbsolutePath);
             }
-            $chapter->setFolder($folderName);
-            $chapter->setCreateDate(new DateTime());
 
-            // @todo: This should be a default value somewhere in Chapter or UploadType!
+            $chapter = new Chapter();
+            $chapter->setCreateDate(new DateTime());
+            $chapter->setDisplayName($data['displayName'] ?: $folderName);
+            $chapter->setFolder($folderName);
             $chapter->setIsDeleted(false);
+            $chapter->setIsHorizontal($data['isHorizontal']);
+            $chapter->setIsPublic($data['isPublic']);
 
             $entityManager->persist($chapter);
             $entityManager->flush();

--- a/src/Form/UploadType.php
+++ b/src/Form/UploadType.php
@@ -15,7 +15,7 @@ class UploadType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('folder', FileType::class, [
+            ->add('files', FileType::class, [
                 'attr' => [
                     'accept' => 'application/zip, image/jpeg',
                     'class' => 'form__input',
@@ -56,7 +56,6 @@ class UploadType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'data_class' => Chapter::class,
             'validation_groups' => ['upload'],
         ]);
     }


### PR DESCRIPTION
The abuse of the 'folder' field for uploaded files led to type mismatch: the field was a string and an array at the same time.

When using the 'folder' as a fallback for 'displayName', this backfired: the processing of the form tried to read from the display name, but read from 'folder' instead, which already held an array, and the type check failed.

Let us not abuse fields any more.

Fixes #85 